### PR TITLE
fix: openai_compatible provider fails with non-OpenAI model names

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -29,6 +29,7 @@ llama-index==0.12.9
 llama-index-embeddings-ollama
 llama-index-vector-stores-chroma
 llama-index-llms-ollama
+llama-index-llms-openai-like
 
 # Retrieval enhancements
 rank_bm25


### PR DESCRIPTION
## Summary
- The `openai_compatible` LLM provider rejects non-OpenAI model names (e.g. `google/gemini-2.5-flash` via OpenRouter) because the LlamaIndex `OpenAI` class validates against a hardcoded model list
- The `openai_compatible` provider was missing from API key mapping functions, so `api_key` resolved to `None` causing authentication failures (502 "Failed to authenticate request with Clerk")

## Changes
- Replace `OpenAI` with `OpenAILike` class for the `openai_compatible` provider — accepts any model name without validation
- Add `openai_compatible` → `OPENAI_API_KEY` to both `_get_api_key()` and `_get_api_key_from_dict()`
- Add `llama-index-llms-openai-like` to `requirements.txt`

## Test plan
- [x] Verified `openai_compatible` provider works with OpenRouter (`google/gemini-2.5-flash`)
- [ ] Verify `ollama` provider still works unchanged
- [ ] Verify other providers (`openai`, `anthropic`, `gemini`) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)